### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/examples/python/hosted_mode/sample_bob.py
+++ b/examples/python/hosted_mode/sample_bob.py
@@ -27,7 +27,7 @@ sdk_short_term_key_callback_list = []
 
 def sdk_short_term_key_callback(local_did, remote_did, secret_key_json):
     # Here you can record in the database, can be used before expiration
-    print(f"SDK short_term_key_callback: {local_did}, {remote_did}, {secret_key_json}")
+    logging.info(f"SDK short_term_key_callback: {local_did}, {remote_did}, [REDACTED]")
     sdk_short_term_key_callback_list.append((local_did, remote_did, secret_key_json))
 
 def get_router_and_user_info(file_name="bob.json"):


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/2](https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/2)

To fix the issue, sensitive data (`secret_key_json`) should not be logged in clear text. Instead, the logging should be removed or replaced with a sanitized version that excludes sensitive information. If logging is necessary for debugging purposes, ensure sensitive data is masked or obfuscated.

The best approach is to replace the `print` statement with a logging statement that excludes sensitive data or masks it. This ensures that debugging information is preserved without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
