### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/agent_connect/python/e2e_encryption/short_term_key_generater.py
+++ b/agent_connect/python/e2e_encryption/short_term_key_generater.py
@@ -426,7 +426,7 @@ class ShortTermKeyGenerater:
             return False
 
         self.state = "finished"
-        logging.info(f"generate_short_term_key_active, success, secret_key_id: {self.secret_key_id}")
+        logging.info("generate_short_term_key_active, success")
         return True
     
     async def generate_short_term_key_passive(self):
@@ -458,6 +458,6 @@ class ShortTermKeyGenerater:
             return False
 
         self.state = "finished"
-        logging.info(f"generate_short_term_key_passive, success, secret_key_id: {self.secret_key_id}")
+        logging.info("generate_short_term_key_passive, success")
         return True
         


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/5](https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/5)

To fix the issue, we should avoid logging the `secret_key_id` directly. Instead, we can log a generic success message without including sensitive information. If necessary, we can log a hashed or redacted version of the `secret_key_id` to provide some traceability without exposing the full value. This ensures that sensitive data is not exposed in the logs while maintaining the ability to debug or trace operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
