### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/agent_connect/python/e2e_encryption/wss_message_sdk.py
+++ b/agent_connect/python/e2e_encryption/wss_message_sdk.py
@@ -181,7 +181,7 @@ class WssMessageSDK:
         key_info = self.short_term_keys.get(secret_key_id, None)
 
         if key_info is None:
-            logging.error(f"Cannot find secret key info: {secret_key_id}")
+            logging.error("Cannot find secret key info. Key ID not found or invalid.")
             # TODO: Send error message later
             return
 


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/10](https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/10)

To fix the issue, we should avoid logging the `secretKeyId` directly. Instead, we can log a generic message that does not include the sensitive identifier. If additional context is needed for debugging, we can log a sanitized or hashed version of the `secretKeyId` to ensure that sensitive information is not exposed.

Steps to fix:
1. Replace the log message on line 184 to exclude the raw `secretKeyId`.
2. Optionally, include a hashed or truncated version of `secretKeyId` in the log message for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
