### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/examples/python/hosted_mode/sample_alice.py
+++ b/examples/python/hosted_mode/sample_alice.py
@@ -24,7 +24,7 @@ TEST_API_KEY = '10090.bo9JAoRCAbQV43FD8kzX5SyEgxCs2R9z'   # Test API key, daily 
 sdk_short_term_key_callback_list = []
 
 def sdk_short_term_key_callback(local_did, remote_did, secret_key_json):
-    print(f"SDK short_term_key_callback: {local_did}, {remote_did}, {secret_key_json}")
+    print(f"SDK short_term_key_callback: {local_did}, {remote_did}, [secret_key_json REDACTED]")
     sdk_short_term_key_callback_list.append((local_did, remote_did, secret_key_json))
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/1](https://github.com/agent-network-protocol/AgentConnect/security/code-scanning/1)

To fix the problem, we should avoid logging the sensitive value `secret_key_json` in clear text. Instead, we can log only non-sensitive information, such as the fact that the callback was invoked and which DIDs were involved, but omit or redact the secret. If it is necessary to log something about the secret for debugging, we can log a constant string (e.g., "[REDACTED]") or, if absolutely necessary, a hash or truncated version (but even this is discouraged for secrets). The change should be made in the `sdk_short_term_key_callback` function in `examples/python/hosted_mode/sample_alice.py`, specifically on line 27.

No new imports or methods are required for a simple redaction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
